### PR TITLE
Add fuzzy matching to command suggestions

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -2,6 +2,7 @@ package seedu.address.commons.util;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -64,5 +65,24 @@ public class StringUtil {
         } catch (NumberFormatException nfe) {
             return false;
         }
+    }
+
+    /**
+     * Returns a string that is a substring of {@code s}. The returned substring begins at index 0 and
+     * extends to the first occurrence of the {@code delimiter} if present and if not, to the end of this string.
+     *
+     * @param s         The original string to operate on.
+     * @param delimiter The delimiter that denotes where the returned substring should end.
+     * @return The substring up till the delimiter (if found) or else the original string.
+     */
+    public static String substringBefore(final String s, final String delimiter) {
+        requireAllNonNull(s, delimiter);
+
+        final int delimiterIndex = s.indexOf(delimiter);
+        if (delimiterIndex == -1) {
+            return s;
+        }
+
+        return s.substring(0, delimiterIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SuggestingCommandUtil.java
+++ b/src/main/java/seedu/address/logic/parser/SuggestingCommandUtil.java
@@ -12,9 +12,11 @@ import seedu.address.logic.commands.EditGroupCommand;
 import seedu.address.logic.commands.EditPersonCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindGroupCommand;
+import seedu.address.logic.commands.FindPersonCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.NusmodCommand;
+import seedu.address.logic.commands.ScheduleCommand;
 import seedu.address.logic.commands.ShowCommand;
 
 /**
@@ -30,12 +32,14 @@ public class SuggestingCommandUtil {
             DeletePersonCommand.COMMAND_WORD,
             EditGroupCommand.COMMAND_WORD,
             EditPersonCommand.COMMAND_WORD,
-            FindGroupCommand.COMMAND_WORD,
-            NusmodCommand.COMMAND_WORD,
-            ShowCommand.COMMAND_WORD,
             ExitCommand.COMMAND_WORD,
+            FindGroupCommand.COMMAND_WORD,
+            FindPersonCommand.COMMAND_WORD,
             HelpCommand.COMMAND_WORD,
-            ListCommand.COMMAND_WORD
+            ListCommand.COMMAND_WORD,
+            NusmodCommand.COMMAND_WORD,
+            ScheduleCommand.COMMAND_WORD,
+            ShowCommand.COMMAND_WORD
     );
     private static ObservableList<String> readOnlyCommandWords = FXCollections.unmodifiableObservableList(commandWords);
 

--- a/src/main/java/seedu/address/logic/parser/SuggestingCommandUtil.java
+++ b/src/main/java/seedu/address/logic/parser/SuggestingCommandUtil.java
@@ -1,5 +1,11 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.StringJoiner;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.logic.commands.AddEventCommand;
@@ -45,5 +51,35 @@ public class SuggestingCommandUtil {
 
     public static ObservableList<String> getCommandWords() {
         return readOnlyCommandWords;
+    }
+
+    /**
+     * Creates a {@link Predicate} that checks if the candidate string contains the {@code input} characters
+     * in the same order while allowing for any printable characters in between and after.
+     * <p>
+     * For example, calling {@code createOrderedMatcher("mdm")} creates a {@link Predicate} where strings such as
+     * "mdm", "modem", "madam", "medium", "madame", "madman" will pass. Note how within the first four examples,
+     * any number of characters can appear between each character in the original string "mdm". The last two examples
+     * show that any characters can also appear after the "mdm" match.
+     *
+     * @param characterSequence A sequence of characters.
+     * @return A {@link Predicate} that checks if the candidate string contains the {@code input} characters
+     * in the same order.
+     */
+    public static Predicate<String> createSequenceMatcher(final String characterSequence) {
+        requireNonNull(characterSequence);
+
+        final String anyPrintableCharacter = "\\w*";
+        final String emptyString = "";
+        final StringJoiner patternBuilder = new StringJoiner(anyPrintableCharacter, emptyString, anyPrintableCharacter);
+
+        characterSequence
+                .codePoints()
+                .mapToObj(Character::toChars)
+                .map(String::valueOf)
+                .map(Pattern::quote)
+                .forEach(patternBuilder::add);
+
+        return Pattern.compile(patternBuilder.toString(), Pattern.UNICODE_CHARACTER_CLASS).asMatchPredicate();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SuggestingCommandUtil.java
+++ b/src/main/java/seedu/address/logic/parser/SuggestingCommandUtil.java
@@ -66,7 +66,7 @@ public class SuggestingCommandUtil {
      * @return A {@link Predicate} that checks if the candidate string contains the {@code input} characters
      * in the same order.
      */
-    public static Predicate<String> createSequenceMatcher(final String characterSequence) {
+    public static Predicate<String> createFuzzyMatcher(final String characterSequence) {
         requireNonNull(characterSequence);
 
         final String anyPrintableCharacter = "\\w*";

--- a/src/main/java/seedu/address/ui/SuggestingCommandBox.java
+++ b/src/main/java/seedu/address/ui/SuggestingCommandBox.java
@@ -155,8 +155,8 @@ public class SuggestingCommandBox extends CommandBox {
                 // the userCommandWord exactly matches a command, so we stop showing suggestions
                 filteredCommandSuggestions.setPredicate((commandWord) -> false);
             } else {
-                final Predicate<String> commandMatcher = SuggestingCommandUtil.createSequenceMatcher(userCommandWord);
-                filteredCommandSuggestions.setPredicate(commandMatcher);
+                final Predicate<String> fuzzyMatcher = SuggestingCommandUtil.createFuzzyMatcher(userCommandWord);
+                filteredCommandSuggestions.setPredicate(fuzzyMatcher);
             }
         });
     }

--- a/src/main/java/seedu/address/ui/SuggestingCommandBox.java
+++ b/src/main/java/seedu/address/ui/SuggestingCommandBox.java
@@ -13,6 +13,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.input.KeyCode;
 import javafx.stage.Popup;
 import javafx.stage.Window;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.SuggestingCommandUtil;
 
 /**
@@ -148,13 +149,7 @@ public class SuggestingCommandBox extends CommandBox {
         });
 
         commandTextField.textProperty().addListener((unused1, unused2, userCommand) -> {
-            final char spaceCharacter = ' ';
-            int spaceCharIdx = userCommand.indexOf(spaceCharacter);
-            if (spaceCharIdx == -1) {
-                spaceCharIdx = userCommand.length();
-            }
-
-            final String userCommandWord = userCommand.substring(0, spaceCharIdx);
+            final String userCommandWord = StringUtil.substringBefore(userCommand, " ");
 
             if (commandSuggestions.contains(userCommandWord)) {
                 // the userCommandWord exactly matches a command, so we stop showing suggestions

--- a/src/main/java/seedu/address/ui/SuggestingCommandBox.java
+++ b/src/main/java/seedu/address/ui/SuggestingCommandBox.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
@@ -154,9 +155,14 @@ public class SuggestingCommandBox extends CommandBox {
             }
 
             final String userCommandWord = userCommand.substring(0, spaceCharIdx);
-            filteredCommandSuggestions.setPredicate(commandWord -> {
-                return commandWord.startsWith(userCommandWord) && !userCommandWord.equals(commandWord);
-            });
+
+            if (commandSuggestions.contains(userCommandWord)) {
+                // the userCommandWord exactly matches a command, so we stop showing suggestions
+                filteredCommandSuggestions.setPredicate((commandWord) -> false);
+            } else {
+                final Predicate<String> commandMatcher = SuggestingCommandUtil.createSequenceMatcher(userCommandWord);
+                filteredCommandSuggestions.setPredicate(commandMatcher);
+            }
         });
     }
 }

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -1,5 +1,6 @@
 package seedu.address.commons.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -138,6 +139,89 @@ public class StringUtilTest {
     @Test
     public void getDetails_nullGiven_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> StringUtil.getDetails(null));
+    }
+
+    //---------------- Tests for substringBefore --------------------------------------
+
+    @Test
+    void substringBefore_nullGiven_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> {
+            StringUtil.substringBefore(null, null);
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            StringUtil.substringBefore("my string", null);
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            StringUtil.substringBefore(null, "my delimiter");
+        });
+    }
+
+    @Test
+    void substringBefore_delimiterPresent_substring() {
+        final String inputString = "hello world";
+        final String delimiter = " ";
+
+        final String expectedSubstring = "hello";
+        final String actualSubstring = StringUtil.substringBefore(inputString, delimiter);
+
+        assertEquals(expectedSubstring, actualSubstring);
+    }
+
+    @Test
+    void substringBefore_multipleDelimitersPresent_firstSubstring() {
+        final String inputString = "first second third";
+        final String delimiter = " ";
+
+        final String expectedSubstring = "first";
+        final String actualSubstring = StringUtil.substringBefore(inputString, delimiter);
+
+        assertEquals(expectedSubstring, actualSubstring);
+    }
+
+    @Test
+    void substringBefore_multiCharacterDelimiter_substring() {
+        final String inputString = "hello";
+        final String delimiter = "ll";
+
+        final String expectedSubstring = "he";
+        final String actualSubstring = StringUtil.substringBefore(inputString, delimiter);
+
+        assertEquals(expectedSubstring, actualSubstring);
+    }
+
+    @Test
+    void substringBefore_delimiterAtStart_emptySubstring() {
+        final String inputString = " hello";
+        final String delimiter = " ";
+
+        final String expectedSubstring = "";
+        final String actualSubstring = StringUtil.substringBefore(inputString, delimiter);
+
+        assertEquals(expectedSubstring, actualSubstring);
+    }
+
+    @Test
+    void substringBefore_emptyString_emptySubstring() {
+        final String inputString = "";
+        final String delimiter = " ";
+
+        final String expectedSubstring = "";
+        final String actualSubstring = StringUtil.substringBefore(inputString, delimiter);
+
+        assertEquals(expectedSubstring, actualSubstring);
+    }
+
+    @Test
+    void substringBefore_delimiterAbsent_originalString() {
+        final String inputString = "hello";
+        final String delimiter = " ";
+
+        final String expectedSubstring = inputString;
+        final String actualSubstring = StringUtil.substringBefore(inputString, delimiter);
+
+        assertEquals(expectedSubstring, actualSubstring);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/SuggestingCommandUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/SuggestingCommandUtilTest.java
@@ -10,109 +10,109 @@ import org.junit.jupiter.api.Test;
 
 public class SuggestingCommandUtilTest {
     @Test
-    void createSequenceMatcher_exactMatch_success() {
+    void createFuzzyMatcher_exactMatch_success() {
         final String sequence = "mdm";
         final String passingMatch = sequence;
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertTrue(predicate.test(passingMatch));
     }
 
     @Test
-    void createSequenceMatcher_oneCharacterBetweenNoTrailing_success() {
+    void createFuzzyMatcher_oneCharacterBetweenNoTrailing_success() {
         final String sequence = "mdm";
         final String passingMatch = "madam";
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertTrue(predicate.test(passingMatch));
     }
 
     @Test
-    void createSequenceMatcher_trailingCharacter_success() {
+    void createFuzzyMatcher_trailingCharacter_success() {
         final String sequence = "mdm";
         final String passingMatch = sequence + "a";
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertTrue(predicate.test(passingMatch));
     }
 
     @Test
-    void createSequenceMatcher_oneCharacterBetweenWithTrailing_success() {
+    void createFuzzyMatcher_oneCharacterBetweenWithTrailing_success() {
         final String sequence = "mdm";
         final String passingMatch = "madame";
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertTrue(predicate.test(passingMatch));
     }
 
     @Test
-    void createSequenceMatcher_manyCharactersBetweenNoTrailing_success() {
+    void createFuzzyMatcher_manyCharactersBetweenNoTrailing_success() {
         final String sequence = "mdm";
         final String passingMatch = "medium";
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertTrue(predicate.test(passingMatch));
     }
 
     @Test
-    void createSequenceMatcher_manyCharactersBetweenWithTrailing_success() {
+    void createFuzzyMatcher_manyCharactersBetweenWithTrailing_success() {
         final String sequence = "mdm";
         final String passingMatch = "madman";
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertTrue(predicate.test(passingMatch));
     }
 
     @Test
-    void createSequenceMatcher_matchUnicodeSurrogatePair_success() {
+    void createFuzzyMatcher_matchUnicodeSurrogatePair_success() {
         final String sequence = "😁😁";
         final String passingMatch = "😁smile😁";
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertTrue(predicate.test(passingMatch));
     }
 
     @Test
-    void createSequenceMatcher_trailingNonLatinCharacters_success() {
+    void createFuzzyMatcher_trailingNonLatinCharacters_success() {
         final String sequence = "mdm";
         final String passingMatch = "mdm你好";
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertTrue(predicate.test(passingMatch));
     }
 
     @Test
-    void createSequenceMatcher_incompleteMatch_fail() {
+    void createFuzzyMatcher_incompleteMatch_fail() {
         final String sequence = "mdm";
         final String failingMatch = "md";
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertFalse(predicate.test(failingMatch));
     }
 
     @Test
-    void createSequenceMatcher_leadingCharacter_fail() {
+    void createFuzzyMatcher_leadingCharacter_fail() {
         final String sequence = "mdm";
         final String failingMatch = "a" + sequence;
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertFalse(predicate.test(failingMatch));
     }
 
     @Test
-    void createSequenceMatcher_spaceInBetween_fail() {
+    void createFuzzyMatcher_spaceInBetween_fail() {
         final String sequence = "mdm";
         final String failingMatch = "m dm";
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertFalse(predicate.test(failingMatch));
     }
 
     @Test
-    void createSequenceMatcher_trailingSpace_fail() {
+    void createFuzzyMatcher_trailingSpace_fail() {
         final String sequence = "mdm";
         final String passingMatch = sequence + " ";
-        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+        final Predicate<String> predicate = SuggestingCommandUtil.createFuzzyMatcher(sequence);
 
         assertFalse(predicate.test(passingMatch));
     }

--- a/src/test/java/seedu/address/logic/parser/SuggestingCommandUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/SuggestingCommandUtilTest.java
@@ -1,0 +1,120 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+
+public class SuggestingCommandUtilTest {
+    @Test
+    void createSequenceMatcher_exactMatch_success() {
+        final String sequence = "mdm";
+        final String passingMatch = sequence;
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertTrue(predicate.test(passingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_oneCharacterBetweenNoTrailing_success() {
+        final String sequence = "mdm";
+        final String passingMatch = "madam";
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertTrue(predicate.test(passingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_trailingCharacter_success() {
+        final String sequence = "mdm";
+        final String passingMatch = sequence + "a";
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertTrue(predicate.test(passingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_oneCharacterBetweenWithTrailing_success() {
+        final String sequence = "mdm";
+        final String passingMatch = "madame";
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertTrue(predicate.test(passingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_manyCharactersBetweenNoTrailing_success() {
+        final String sequence = "mdm";
+        final String passingMatch = "medium";
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertTrue(predicate.test(passingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_manyCharactersBetweenWithTrailing_success() {
+        final String sequence = "mdm";
+        final String passingMatch = "madman";
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertTrue(predicate.test(passingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_matchUnicodeSurrogatePair_success() {
+        final String sequence = "😁😁";
+        final String passingMatch = "😁smile😁";
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertTrue(predicate.test(passingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_trailingNonLatinCharacters_success() {
+        final String sequence = "mdm";
+        final String passingMatch = "mdm你好";
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertTrue(predicate.test(passingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_incompleteMatch_fail() {
+        final String sequence = "mdm";
+        final String failingMatch = "md";
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertFalse(predicate.test(failingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_leadingCharacter_fail() {
+        final String sequence = "mdm";
+        final String failingMatch = "a" + sequence;
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertFalse(predicate.test(failingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_spaceInBetween_fail() {
+        final String sequence = "mdm";
+        final String failingMatch = "m dm";
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertFalse(predicate.test(failingMatch));
+    }
+
+    @Test
+    void createSequenceMatcher_trailingSpace_fail() {
+        final String sequence = "mdm";
+        final String passingMatch = sequence + " ";
+        final Predicate<String> predicate = SuggestingCommandUtil.createSequenceMatcher(sequence);
+
+        assertFalse(predicate.test(passingMatch));
+    }
+
+}


### PR DESCRIPTION
# Issue

Issue number - #81 

# PR type

Refined user story implementation

# Details
- Added new commands to suggestions
- Command suggestions are now fuzzy matching (e.g. typing in `dg` will suggest `deletegroup`)
- Code quality cleanup by creating a `StringUtil.substringBefore` method and using it in `SuggestingCommandBox`
