### PR TITLE
Fix tag suggestion for editperson and edituser commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/suggestions/EditPersonCommandSuggester.java
+++ b/src/main/java/seedu/address/logic/commands/suggestions/EditPersonCommandSuggester.java
@@ -12,7 +12,6 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
-import seedu.address.model.tag.Tag;
 
 /**
  * Provides suggestions for the {@link Prefix}es of the {@link seedu.address.logic.commands.EditPersonCommand}.
@@ -74,7 +73,9 @@ public class EditPersonCommandSuggester extends Suggester {
                 return selectedPerson
                         .getTags()
                         .stream()
-                        .map(Tag::toString)
+                        .map(tag -> {
+                            return tag.tagName;
+                        })
                         .collect(Collectors.toUnmodifiableList());
             }
         }

--- a/src/main/java/seedu/address/logic/commands/suggestions/EditUserCommandSuggester.java
+++ b/src/main/java/seedu/address/logic/commands/suggestions/EditUserCommandSuggester.java
@@ -9,7 +9,6 @@ import seedu.address.logic.parser.CommandArgument;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
-import seedu.address.model.tag.Tag;
 
 /**
  * Provides suggestions for the {@link Prefix}es of the {@link seedu.address.logic.commands.EditUserCommand}.
@@ -48,7 +47,9 @@ public class EditUserCommandSuggester extends Suggester {
             return user
                     .getTags()
                     .stream()
-                    .map(Tag::toString)
+                    .map(tag -> {
+                        return tag.tagName;
+                    })
                     .collect(Collectors.toUnmodifiableList());
         }
 

--- a/src/test/java/seedu/address/logic/commands/suggestions/EditPersonCommandSuggesterTest.java
+++ b/src/test/java/seedu/address/logic/commands/suggestions/EditPersonCommandSuggesterTest.java
@@ -17,7 +17,6 @@ import seedu.address.logic.parser.CliSyntax;
 import seedu.address.logic.parser.CommandArgument;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.PersonDescriptor;
-import seedu.address.model.tag.Tag;
 import seedu.address.testutil.personutil.TypicalPersonDescriptor;
 
 class EditPersonCommandSuggesterTest extends EditCommandSuggesterTest {
@@ -36,7 +35,9 @@ class EditPersonCommandSuggesterTest extends EditCommandSuggesterTest {
     static Stream<Arguments> knownPersonPrefixesAndValueGenerator() {
         final Collection<String> tags = KNOWN_PERSON.getTags()
                 .stream()
-                .map(Tag::toString)
+                .map(tag -> {
+                    return tag.tagName;
+                })
                 .collect(Collectors.toUnmodifiableList());
 
         return Stream.of(

--- a/src/test/java/seedu/address/logic/commands/suggestions/EditUserCommandSuggesterTest.java
+++ b/src/test/java/seedu/address/logic/commands/suggestions/EditUserCommandSuggesterTest.java
@@ -19,7 +19,6 @@ import seedu.address.logic.parser.CommandArgument;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
-import seedu.address.model.tag.Tag;
 import seedu.address.testutil.personutil.TypicalPersonDescriptor;
 
 class EditUserCommandSuggesterTest extends SuggesterImplTester {
@@ -51,7 +50,9 @@ class EditUserCommandSuggesterTest extends SuggesterImplTester {
     static Stream<Arguments> knownPersonPrefixesAndValueGenerator() {
         final Collection<String> tags = KNOWN_PERSON.getTags()
                 .stream()
-                .map(Tag::toString)
+                .map(tag -> {
+                    return tag.tagName;
+                })
                 .collect(Collectors.toUnmodifiableList());
 
         return Stream.of(


### PR DESCRIPTION
# Issue

Issue number - #81

# PR type

Resolve bug where the `tag/` suggestions for `editperson` and `edituser` commands included the square brackets (see screenshot in issue #225)